### PR TITLE


### DIFF
--- a/cascade/lint-baseline.xml
+++ b/cascade/lint-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 9.0.0-beta05" type="baseline" client="gradle" dependencies="false" name="AGP (9.0.0-beta05)" variant="all" version="9.0.0-beta05">
+
+</issues>

--- a/genesis/lint-baseline.xml
+++ b/genesis/lint-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 9.0.0-beta05" type="baseline" client="gradle" dependencies="false" name="AGP (9.0.0-beta05)" variant="all" version="9.0.0-beta05">
+
+</issues>

--- a/utilities/lint-baseline.xml
+++ b/utilities/lint-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 9.0.0-beta05" type="baseline" client="gradle" dependencies="false" name="AGP (9.0.0-beta05)" variant="all" version="9.0.0-beta05">
+
+</issues>


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Introduce lint-baseline.xml files for the cascade, genesis, and utilities modules to capture current lint state under AGP 9.0.0-beta05.